### PR TITLE
fix: Updated image tag as new image is published for major version only

### DIFF
--- a/scripts/bullseye.docker
+++ b/scripts/bullseye.docker
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23.2-1-bullseye AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.23-bullseye AS builder
 WORKDIR /go/src/github.com/influxdata/telegraf
 
 COPY . /go/src/github.com/influxdata/telegraf


### PR DESCRIPTION
## Summary
<!-- Mandatory
S360 nov24 patching 1
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
