### PR TITLE
fix: Copying original ldd source for S360 - https://security-tracker.…

### DIFF
--- a/scripts/bullseye.docker
+++ b/scripts/bullseye.docker
@@ -13,6 +13,7 @@ RUN go build cmd/oauth/get_oauth2_token_password_credentials.go
 FROM buildpack-deps:bullseye-curl
 COPY --from=builder /go/bin/* /usr/bin/
 COPY etc/telegraf.conf /etc/telegraf/telegraf.conf
+COPY --from=builder /usr/bin/ldd /usr/bin/ldd
 
 RUN mkdir -p /tmp/telegraf
 COPY --from=builder /go/bin/* /usr/bin/


### PR DESCRIPTION
fix: Copying original ldd source for S360 - https://security-tracker.debian.org/tracker/CVE-2025-0395

## Summary
<!-- Mandatory
Explain here the why, the rationale and motivation, for the changes.
-->

## Checklist
<!-- Mandatory
Please confirm the following by replacing the space with an "x" between the []:
-->

- [ ] No AI generated code was used in this PR

## Related issues
<!-- Mandatory
All PRs should resolve an issue, if one does not exist, please open one.
-->

resolves #
