### PR TITLE
fix: added support for MI

### DIFF
--- a/plugins/inputs/eventhub_consumer/sample.conf
+++ b/plugins/inputs/eventhub_consumer/sample.conf
@@ -25,11 +25,49 @@
   ## Connection string should contain EventHubName (EntityPath)
   # connection_string = ""
 
+  ## Azure Managed Identity Authentication
+  ## Enable this option to use Azure Managed Identity for authentication instead of connection strings or environment variables.
+  ## The plugin supports both traditional Managed Identity (for VMs) and Azure Workload Identity (for AKS pods).
+  # use_managed_identity = false
+
+  ## Event Hub namespace (required when using managed identity)
+  ## This should be the fully qualified namespace name (e.g., "myeventhubnamespace.servicebus.windows.net")
+  # eventhub_namespace = ""
+
+  ## Event Hub name (required when using managed identity)
+  ## This should be the name of the specific Event Hub within the namespace
+  # eventhub_name = ""
+
+  ## Managed Identity Client ID (optional)
+  ## If specified, will use User-Assigned Managed Identity with the given client ID.
+  ## If not specified (or empty), will use System-Assigned Managed Identity.
+  ## This should be the client ID (GUID) of the User-Assigned Managed Identity.
+  ## 
+  ## Azure Workload Identity Support (AKS):
+  ## When running in AKS with Azure Workload Identity enabled, the plugin automatically detects
+  ## the workload identity environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_FEDERATED_TOKEN_FILE)
+  ## and uses OIDC token exchange for authentication. This is the preferred method for AKS deployments.
+  ##
+  ## Authentication Priority (when use_managed_identity = true):
+  ## 1. Azure Workload Identity (if environment variables are detected)
+  ## 2. User-Assigned Managed Identity (if managed_identity_id is specified)
+  ## 3. System-Assigned Managed Identity (default fallback)
+  ##
+  ## Troubleshooting:
+  ## - Ensure the identity has "Azure Event Hubs Data Receiver" role on the Event Hub namespace
+  ## - For Workload Identity: verify the service account has proper annotations and federated credentials
+  ## - For Managed Identity: ensure the identity exists and is accessible from the pod/VM
+  ## - Check Azure roles and permissions on both the identity and Event Hub resources
+  # managed_identity_id = ""
+
   ## Set persistence directory to a valid folder to use a file persister instead of an in-memory persister
   # persistence_dir = ""
 
   ## Change the default consumer group
-  # consumer_group = ""
+  ## When using managed identity, this specifies which consumer group to use for reading from the Event Hub.
+  ## The default is "$Default" which is the standard Event Hub consumer group.
+  ## Each consumer group maintains its own set of offsets for tracking message consumption.
+  # consumer_group = "$Default"
 
   ## By default the event hub receives all messages present on the broker, alternative modes can be set below.
   ## The timestamp should be in https://github.com/toml-lang/toml#offset-date-time format (RFC 3339).


### PR DESCRIPTION
## Summary
<!-- Mandatory
Adding support for Managed Identity
-->

   Managed Identity Client ID (optional)
   If specified, will use User-Assigned Managed Identity with the given client ID.
   If not specified (or empty), will use System-Assigned Managed Identity.
   This should be the client ID (GUID) of the User-Assigned Managed Identity.
   
   Azure Workload Identity Support (AKS):
   When running in AKS with Azure Workload Identity enabled, the plugin automatically detects
   the workload identity environment variables (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_FEDERATED_TOKEN_FILE)
   and uses OIDC token exchange for authentication. This is the preferred method for AKS deployments.
  
   Authentication Priority (when use_managed_identity = true):
   1. Azure Workload Identity (if environment variables are detected)
   2. User-Assigned Managed Identity (if managed_identity_id is specified)
   3. System-Assigned Managed Identity (default fallback)